### PR TITLE
style: improve button color contrast

### DIFF
--- a/apps/docs/app/css/global.css
+++ b/apps/docs/app/css/global.css
@@ -40,7 +40,7 @@
   --background: 0 0% 4%; /* neutral-900 */
   --foreground: 0 0% 96%; /* neutral-100 */
 
-  --card: 0 0% 7%; /* #131313 */
+  --card: 0 0% 7%; /* neutral-925 */
   --card-foreground: 0 0% 96%; /* neutral-100 */
 
   --muted: 0 0% 15%; /* neutral-800 */

--- a/apps/docs/app/css/theme.css
+++ b/apps/docs/app/css/theme.css
@@ -15,7 +15,7 @@
   --mijnui-primary: 29 100% 52%; /* orange-500 */
   --mijnui-primary-text: 0 0% 100%; /* white */
 
-  --mijnui-secondary: 33 100% 87% /* #FED7AA */;
+  --mijnui-secondary: 33 100% 87%; /* orange-200 */
   --mijnui-secondary-text: 29 93% 39%; /* orange-700 */
 
   --mijnui-info: 216 76% 52%; /* blue-500 */
@@ -51,7 +51,7 @@
   --mijnui-surface-text: 0 0% 96%; /* neutral-100 */
 
   --mijnui-neutral: 0 0% 15%; /* neutral-800 */
-  --mijnui-neutral-text: 0 0% 64%; /* neutral-400 */
+  --mijnui-neutral-text: 0 0% 83%; /* neutral-300 */
 
   --mijnui-accent: 0 0% 12%; /* neutral-850 */
   --mijnui-accent-text: 0 0% 96%; /* neutral-100 */
@@ -59,7 +59,7 @@
   --mijnui-primary: 29 100% 52%; /* orange-500 */
   --mijnui-primary-text: 0 0% 100%; /* white */
 
-  --mijnui-secondary: 34 100% 82%; /* #FED7AA */
+  --mijnui-secondary: 34 100% 82%; /* orange-200 */
   --mijnui-secondary-text: 29 93% 39%; /* orange-700 */
 
   --mijnui-info: 216 76% 52%; /* blue-500 */

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -47,7 +47,7 @@ const buttonStyles = cva(
         color: "secondary",
         variant: "outline",
         className:
-          "border-secondary text-secondary hover:bg-secondary hover:text-secondary-text border",
+          "border-secondary text-secondary-text dark:text-secondary hover:bg-secondary dark:hover:text-secondary-text border",
       },
       {
         color: "accent",
@@ -77,7 +77,7 @@ const buttonStyles = cva(
         color: "secondary",
         variant: "text",
         className:
-          "text-secondary hover:bg-secondary hover:text-secondary-text",
+          "text-secondary-text dark:text-secondary hover:bg-secondary dark:hover:text-secondary-text",
       },
       {
         color: "danger",


### PR DESCRIPTION
- Better color contrast for secondary and neutral button variants in both light and dark modes
- Changed `neutral-text` color to a lighter color for better contrast in dark background
- Updated theme color names from hex code to tailwind color naming scheme