### PR TITLE
refactor(packages|command): refactor CommandInput to use Input component (Issue #56)

### DIFF
--- a/packages/components/command/package.json
+++ b/packages/components/command/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@mijn-ui/react-dialog": "workspace:*",
     "@mijn-ui/shared-icons": "workspace:*",
+    "@mijn-ui/react-input": "workspace:*",
     "@mijn-ui/react-utilities": "workspace:*",
     "@mijn-ui/react-hooks": "workspace:*",
     "cmdk": "^1.0.4"

--- a/packages/components/command/src/command.stories.tsx
+++ b/packages/components/command/src/command.stories.tsx
@@ -84,7 +84,6 @@ const CommandUnstyled = (args: CommandProps) => {
     <Command
       className="border-border rounded-large border-small shadow-medium p-3 md:w-[300px]"
       classNames={{
-        inputWrapper: "flex items-center gap-2",
         item: "flex items-center pointer-events-none",
         shortcut: "ml-auto",
         separator: "border-b-2",
@@ -92,7 +91,10 @@ const CommandUnstyled = (args: CommandProps) => {
       }}
       {...args}
     >
-      <CommandInput placeholder="Type a command or search..." />
+      <CommandInput
+        placeholder="Type a command or search..."
+        className="flex items-center gap-2"
+      />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Suggestions">

--- a/packages/components/command/src/command.tsx
+++ b/packages/components/command/src/command.tsx
@@ -135,7 +135,8 @@ const CommandInput = ({
   onValueChange,
   ...props
 }: CommandInputProps) => {
-  const { input, inputIcon, inputPrimitive, inputWrapper, classNames } =
+  const context = useCommandContext()
+  const { input, inputIcon, inputWrapper, classNames } =
     useCommandStyles(unstyled)
   const [fallbackValue, setFallbackValue] = React.useState("")
   const isControlled = externalValue !== undefined
@@ -164,7 +165,7 @@ const CommandInput = ({
             className: classNames?.input,
           }),
         }}
-        className={cn(className)}
+        className={className}
         value={value}
         onChange={handleChange}
         startIcon={
@@ -174,10 +175,11 @@ const CommandInput = ({
             })}
           />
         }
+        unstyled={context.unstyled}
         {...props}
       />
       <CommandPrimitive.Input
-        className={inputPrimitive()}
+        className="hidden"
         value={value}
         onValueChange={onValueChange}
       />

--- a/packages/components/command/src/command.tsx
+++ b/packages/components/command/src/command.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { createTVUnstyledSlots } from "@mijn-ui/react-core"
 import { Dialog, DialogContent, type DialogProps } from "@mijn-ui/react-dialog"
 import { useTVUnstyled } from "@mijn-ui/react-hooks"
+import { Input } from "@mijn-ui/react-input"
 import {
   CommandSlots,
   UnstyledComponentWithSlots,
@@ -127,9 +128,27 @@ type CommandInputProps = React.ComponentPropsWithRef<
 > &
   UnstyledProps
 
-const CommandInput = ({ className, unstyled, ...props }: CommandInputProps) => {
-  const { input, inputIcon, inputWrapper, classNames } =
+const CommandInput = ({
+  className,
+  unstyled,
+  value: externalValue,
+  onValueChange,
+  ...props
+}: CommandInputProps) => {
+  const { input, inputIcon, inputPrimitive, inputWrapper, classNames } =
     useCommandStyles(unstyled)
+  const [fallbackValue, setFallbackValue] = React.useState("")
+  const isControlled = externalValue !== undefined
+  const value = isControlled ? externalValue : fallbackValue
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    if (isControlled) {
+      onValueChange?.(newValue)
+    } else {
+      setFallbackValue(newValue)
+    }
+  }
 
   return (
     <div
@@ -139,16 +158,28 @@ const CommandInput = ({ className, unstyled, ...props }: CommandInputProps) => {
       /* eslint-disable-next-line */
       cmdk-input-wrapper=""
     >
-      <SearchIcon
-        className={inputIcon({
-          className: classNames?.inputIcon,
-        })}
+      <Input
+        classNames={{
+          input: input({
+            className: classNames?.input,
+          }),
+        }}
+        className={cn(className)}
+        value={value}
+        onChange={handleChange}
+        startIcon={
+          <SearchIcon
+            className={inputIcon({
+              className: classNames?.inputIcon,
+            })}
+          />
+        }
+        {...props}
       />
       <CommandPrimitive.Input
-        className={input({
-          className: cn(classNames?.input, className),
-        })}
-        {...props}
+        className={inputPrimitive()}
+        value={value}
+        onValueChange={onValueChange}
       />
     </div>
   )

--- a/packages/theme/src/components/command.ts
+++ b/packages/theme/src/components/command.ts
@@ -12,10 +12,11 @@ const commandStyles = tv({
     group:
       "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-tiny [&_[cmdk-group-heading]]:font-medium",
     separator: "bg-border -mx-1 h-divider",
-    inputWrapper: "border-border flex items-center border-b px-3",
-    inputIcon: "mr-2 size-4 shrink-0 opacity-50",
+    inputWrapper: "border-border flex items-center border-b px-1",
+    inputIcon: "",
+    inputPrimitive: "hidden",
     input:
-      "placeholder:text-muted-foreground flex h-11 w-full rounded-medium bg-transparent py-3 text-small outline-none disabled:cursor-not-allowed disabled:opacity-disabled",
+      "border-none bg-transparent focus-visible:border-none focus-visible:ring-0",
     item: "data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default select-none items-center rounded-medium px-2 py-1.5 text-small outline-none data-[disabled]:pointer-events-auto data-[disabled=true]:opacity-disabled",
     empty: "py-6 text-center text-small",
     shortcut: "text-muted-foreground ml-auto text-tiny tracking-widest",

--- a/packages/theme/src/components/command.ts
+++ b/packages/theme/src/components/command.ts
@@ -14,7 +14,6 @@ const commandStyles = tv({
     separator: "bg-border -mx-1 h-divider",
     inputWrapper: "border-border flex items-center border-b px-1",
     inputIcon: "",
-    inputPrimitive: "hidden",
     input:
       "border-none bg-transparent focus-visible:border-none focus-visible:ring-0",
     item: "data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default select-none items-center rounded-medium px-2 py-1.5 text-small outline-none data-[disabled]:pointer-events-auto data-[disabled=true]:opacity-disabled",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -722,6 +722,9 @@ importers:
       '@mijn-ui/react-hooks':
         specifier: workspace:*
         version: link:../../hooks
+      '@mijn-ui/react-input':
+        specifier: workspace:*
+        version: link:../input
       '@mijn-ui/react-utilities':
         specifier: workspace:*
         version: link:../../utilities/react-utilities


### PR DESCRIPTION
### Problem
We can't replace `CommandPrimitive.Input` with `Input` because `CommandPrimitive.Input` has filter functionality that works together with other `cmdk` components.

### Solution
`Input` is used as a dummy input while `CommandPrimitive.Input` is hidden and its value is synchronized with `Input` using an internal state to ensure filtering still works. Users might want to have `CommandInput` as a controlled component, so the two inputs are configured to primarily use external value for synchronization, while also having an internal state as fallback.

### Other Changes
- added `@mijn-ui/react-input` dependency
- `SearchIcon` is passed into `Input` rather than being its own component.
- Styles for `input` and `inputIcon` are removed from `theme`, except a few to keep the original design.
- ~`inputPrimitive` is added to `theme` for styling `CommandPrimitive.Input`.~ This causes `CommandPrimitive.Input` to appear when `unstyled` is `true` and also exposes non-functional `inputPrimitive` field in `classNames`, so it is replaced with hard-coded Tailwind class.
- `{...props}` is removed from `CommandPrimitive.Input` to avoid ref conflicts with `Input`.
- `unstyled` is applied to `Input` using the value from context.

### Related Issues
Fixes #56